### PR TITLE
Scope hook urls to account id

### DIFF
--- a/gohookd/service.go
+++ b/gohookd/service.go
@@ -17,13 +17,11 @@ type Service interface {
 type ServiceOpts struct {
 	Origin   string
 	Protocol string
-	Route    string
 }
 
 var DefaultServiceOpts = ServiceOpts{
 	Protocol: "http",
 	Origin:   "localhost",
-	Route:    "hook",
 }
 
 func NewServiceOpts() *ServiceOpts {
@@ -64,7 +62,7 @@ func (s *basicService) Create(ctx context.Context, request HookRequest) (*Hook, 
 	id := uuid.NewV4()
 	newHook := &Hook{
 		Id:     HookID(id.String()),
-		Url:    fmt.Sprintf("%s://%s/%s/%s", s.opts.Protocol, s.opts.Origin, s.opts.Route, id.String()),
+		Url:    fmt.Sprintf("%s://%s/%s/%s", s.opts.Protocol, s.opts.Origin, account.Id, id.String()),
 		Method: request.Method,
 	}
 	err := s.hooks.Scope(account.Id).Add(newHook)

--- a/webhook/middleware.go
+++ b/webhook/middleware.go
@@ -41,6 +41,7 @@ func (mw serviceLoggingMiddleware) Trigger(ctx context.Context, trigger TriggerR
 		mw.logger.Log(
 			"method", "Trigger",
 			"layer", "service",
+			"accountId", trigger.AccountId,
 			"hookId", trigger.HookId,
 			"error", err,
 			"took", time.Since(begin),

--- a/webhook/service.go
+++ b/webhook/service.go
@@ -23,7 +23,7 @@ type basicService struct {
 }
 
 func (s basicService) Trigger(_ context.Context, trigger TriggerRequest) (*TriggerResponse, error) {
-	hook, err := s.hooks.Find(trigger.HookId)
+	hook, err := s.hooks.Scope(trigger.AccountId).Find(trigger.HookId)
 	if err != nil {
 		return nil, err
 	}

--- a/webhook/transport_http.go
+++ b/webhook/transport_http.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/kit/log"
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/gohook/gohook-server/gohookd"
+	"github.com/gohook/gohook-server/user"
 	"github.com/gorilla/mux"
 	"golang.org/x/net/context"
 )
@@ -18,7 +19,7 @@ func MakeWebhookHTTPServer(ctx context.Context, endpoints Endpoints, logger log.
 		httptransport.ServerErrorLogger(logger),
 	}
 	m := mux.NewRouter()
-	m.Handle("/hook/{hookId}", httptransport.NewServer(
+	m.Handle("/{accountId}/{hookId}", httptransport.NewServer(
 		ctx,
 		endpoints.TriggerEndpoint,
 		DecodeHTTPTriggerRequest,
@@ -54,14 +55,16 @@ func errorEncoder(_ context.Context, err error, w http.ResponseWriter) {
 
 func DecodeHTTPTriggerRequest(_ context.Context, r *http.Request) (request interface{}, err error) {
 	hookId := mux.Vars(r)["hookId"]
+	accountId := mux.Vars(r)["accountId"]
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}
 	req := TriggerRequest{
-		HookId: gohookd.HookID(hookId),
-		Method: r.Method,
-		Body:   body,
+		AccountId: user.AccountId(accountId),
+		HookId:    gohookd.HookID(hookId),
+		Method:    r.Method,
+		Body:      body,
 	}
 	return req, nil
 }

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -2,12 +2,14 @@ package webhook
 
 import (
 	"github.com/gohook/gohook-server/gohookd"
+	"github.com/gohook/gohook-server/user"
 )
 
 type TriggerRequest struct {
-	HookId gohookd.HookID
-	Method string
-	Body   []byte
+	AccountId user.AccountId
+	HookId    gohookd.HookID
+	Method    string
+	Body      []byte
 }
 
 type TriggerResponse struct {


### PR DESCRIPTION
This will add a layer of obscurity and limit the posibility of brute
force attacks. We should be able to make the hooks a little bit shorter
now since conflicts will be less likely.